### PR TITLE
Add extension for quarto_jll

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,36 +1,102 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[Base64]]
-uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+julia_version = "1.11.6"
+manifest_format = "2.0"
+project_hash = "f9342ff9ef1b36660989d5d7b7fbb30c1d20724d"
 
-[[Dates]]
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
-[[JSON]]
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.7.1"
+
+[[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.4"
 
-[[Mmap]]
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
+
+[[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
-[[Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.15"
+version = "2.8.3"
 
-[[Printf]]
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "0f27480397253da18fe2c12a4ba4eb9eb208bf3d"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.0"
+
+[[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
-[[Unicode]]
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.StringEncodings]]
+deps = ["Libiconv_jll"]
+git-tree-sha1 = "b765e46ba27ecf6b44faf70df40c57aa3a547dcb"
+uuid = "69024149-9ee7-55f6-a4c4-859efe599b68"
+version = "0.3.7"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
-[[YAML]]
-deps = ["Base64", "Dates", "Printf"]
-git-tree-sha1 = "78c02bd295bbd0ca330f95e07ccdfcb69f6cbcd4"
+[[deps.YAML]]
+deps = ["Base64", "Dates", "Printf", "StringEncodings"]
+git-tree-sha1 = "2f58ac39f64b41fb812340347525be3b590cce3b"
 uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
-version = "0.4.6"
+version = "0.4.14"

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,20 @@
 name = "Quarto"
 uuid = "d7167be5-f61b-4dc9-b75c-ab62374668c5"
 authors = ["JJ Allaire <jj@rstudio.com>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
+[weakdeps]
+quarto_jll = "b7163347-bfae-5fd9-aba4-19f139889d78"
+
+[extensions]
+QuartoExt = "quarto_jll"
+
 [compat]
-julia = "1.5"
-YAML = "0.4.3"
 JSON = "0.21.0"
+YAML = "0.4.3"
+julia = "1.5"
+quarto_jll = "1.7.32"

--- a/ext/QuartoExt/QuartoExt.jl
+++ b/ext/QuartoExt/QuartoExt.jl
@@ -1,0 +1,8 @@
+module QuartoExt
+
+using Quarto
+using quarto_jll
+
+quarto_bin = quarto_jll.quarto()
+
+end

--- a/ext/QuartoExt/QuartoExt.jl
+++ b/ext/QuartoExt/QuartoExt.jl
@@ -3,6 +3,4 @@ module QuartoExt
 using Quarto
 using quarto_jll
 
-quarto_bin = quarto_jll.quarto()
-
 end

--- a/src/Quarto.jl
+++ b/src/Quarto.jl
@@ -109,6 +109,11 @@ function metadata(input::AbstractString)
 end
 
 function path()
+  # check if the QuartoExt module is loaded
+  ext = Base.get_extension(@__MODULE__, :QuartoExt)
+  if !isnothing(ext)
+    return ext.quarto_bin
+  end
   if (haskey(ENV, "QUARTO_PATH"))
     return ENV["QUARTO_PATH"]
   else

--- a/src/Quarto.jl
+++ b/src/Quarto.jl
@@ -112,7 +112,7 @@ function path()
   # check if the QuartoExt module is loaded
   ext = Base.get_extension(@__MODULE__, :QuartoExt)
   if !isnothing(ext)
-    return ext.quarto_bin
+    return ext.quarto_jll.quarto()
   end
   if (haskey(ENV, "QUARTO_PATH"))
     return ENV["QUARTO_PATH"]


### PR DESCRIPTION
This adds `QuartoExt` which is an extension module that uses the path of quarto found in the quarto_jll artifact. 

This will only update the path when quarto_jll is used. Otherwise, it should behave as it always has.